### PR TITLE
Godbolt rendering in assets

### DIFF
--- a/copacabana/cmake/asset/godbolt.js
+++ b/copacabana/cmake/asset/godbolt.js
@@ -3,6 +3,18 @@
 //  Copyright : Copacabana Project Contributors
 //  SPDX-License-Identifier: BSL-1.0
 //==================================================================================================
+const godboltTabFix = document.createElement("style");
+godboltTabFix.innerHTML = `
+  .tabbed,
+  .tabbed > ul,
+  .tabbed > ul > li {
+    height: auto !important;
+    max-height: none !important;
+    transition: none !important;
+  }
+`;
+document.head.appendChild(godboltTabFix);
+
 function escapeHtml(str) {
     const escapeMap = {
         '&': '&amp;',


### PR DESCRIPTION
This PR fixes rendering issue when using godbolt inside doxygen-awesome tabs where the output block was always hidden.

By default doxygen awesome fixes the size of the different tab sections. As we rely on compiler-explorer sending back the result before printing this is incompatible (dynamic size).